### PR TITLE
Dictionary Char List

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.d
 *.o
 tests/test-spellcheck
+settings.json

--- a/include/dictionary.h
+++ b/include/dictionary.h
@@ -7,7 +7,7 @@
 
 #include "mock_trie.h"
 
-#define MAXLEN 100
+#define MAXSTRLEN 60
 
 /* A dictionary and a instant lookup table of the characters contained in it */
 typedef struct {

--- a/include/dictionary.h
+++ b/include/dictionary.h
@@ -7,9 +7,12 @@
 
 #include "mock_trie.h"
 
-/* A point in two-dimensional space */
+#define MAXLEN 100
+
+/* A dictionary and a instant lookup table of the characters contained in it */
 typedef struct {
     trie_t *dict;
+    char *char_list;
 } dict_t;
 
 
@@ -49,6 +52,31 @@ int dict_init(dict_t *d);
  */
 int dict_free(dict_t *d);
 
+/*
+ * Returns whether a character is in the character list
+ * 
+ * Parameters:
+ *  - d: A dictionary. Must point to a dictionary allocated with dict_new
+ *  - c: A character
+ * 
+ * Returns:
+ *  - EXIT_SUCCESS if the character is contained in the dictionary
+ *  - EXIT_FAILURE if it isn't
+ */
+int dict_chars_exists(dict_t *d, char c);
+
+/*
+ * Updates the character list with potential new characters from a string
+ * 
+ * Parameters:
+ *  - d: A dictionary. Must point to a dictionary allocated with dict_new
+ *  - str: a string
+ * 
+ * Returns:
+ *  - EXIT_SUCCESS on success, 
+ *  - EXIT_FAILURE if an error occurs
+ */
+int dict_chars_update(dict_t *d, char *str);
 
 /*
  * Checks if a string is contained in a dictionary

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -86,7 +86,7 @@ int dict_chars_update(dict_t *d, char *str) {
     assert(str != NULL);
     
     int i;
-    int len = strnlen(str, MAXLEN);
+    int len = strnlen(str, MAXSTRLEN);
 
     if (str[len] != '\0') {
         return EXIT_FAILURE;
@@ -118,6 +118,10 @@ int dict_add(dict_t *d, char *str) {
         return EXIT_FAILURE;
     }
 
+    if (strnlen(str, MAXSTRLEN+1) == MAXSTRLEN+1) {
+        return EXIT_FAILURE;
+    }
+
     // Attempt to add new characters to the dictionary character list
     if (dict_chars_update(d, str) == EXIT_FAILURE) {
         return EXIT_FAILURE;
@@ -130,14 +134,14 @@ int dict_add(dict_t *d, char *str) {
 int dict_read(dict_t *d, char *file) {
 
     // From here: https://stackoverflow.com/questions/16400886/reading-from-a-file-word-by-word
-    char buffer[1024];
+    char buffer[MAXSTRLEN + 1];
     FILE *f = fopen(file, "r");
 
     if (f == NULL) {
         return EXIT_FAILURE;
     }
 
-    while (fscanf(f, "%1023s", buffer) == 1) {
+    while (fscanf(f, "%100s", buffer) == 1) {
         if (dict_add(d, buffer) != EXIT_SUCCESS) {
             return EXIT_FAILURE;
         }

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -56,7 +56,9 @@ int dict_init(dict_t *d) {
 int dict_free(dict_t *d) {
     assert(d != NULL);
     assert(d->dict != NULL);
+    assert(d->char_list != NULL);
 
+    free(d->char_list);
     trie_free(d->dict);
     free(d);
 

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <unistd.h>
+#include <string.h>
 #include "dictionary.h"
 
 /* See dictionary.h */
@@ -42,6 +43,12 @@ int dict_init(dict_t *d) {
     }
     d->dict = t;
 
+    char *char_list = (char*)calloc(sizeof(char), 256);
+    if (char_list == NULL) {
+        return EXIT_FAILURE;
+    }
+    d->char_list = char_list;
+
     return EXIT_SUCCESS;
 }
 
@@ -53,6 +60,44 @@ int dict_free(dict_t *d) {
     trie_free(d->dict);
     free(d);
 
+    return EXIT_SUCCESS;
+}
+
+int dict_chars_exists(dict_t *d, char c) {
+    assert(d != NULL);
+    assert(d->char_list != NULL);
+
+    // Use the character as the index
+    int index = (int)c;
+
+    if (d->char_list[index] == '\0') {
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}
+
+/* See dictionary.h */
+int dict_chars_update(dict_t *d, char *str) {
+    assert(d != NULL);
+    assert(d->char_list != NULL);
+    assert(str != NULL);
+    
+    int i;
+    int len = strnlen(str, MAXLEN);
+
+    if (str[len] != '\0') {
+        return EXIT_FAILURE;
+    }
+
+    for (i = 0; i < len; i++) {
+        
+        // Use each character as a hash
+        int index = (int)str[i];
+
+        d->char_list[index] = str[i];
+    }
+    
     return EXIT_SUCCESS;
 }
 
@@ -68,6 +113,11 @@ int dict_exists(dict_t *d, char *str) {
 /* See dictionary.h */
 int dict_add(dict_t *d, char *str) {
     if (d == NULL || d->dict == NULL || str == NULL) {
+        return EXIT_FAILURE;
+    }
+
+    // Attempt to add new characters to the dictionary character list
+    if (dict_chars_update(d, str) == EXIT_FAILURE) {
         return EXIT_FAILURE;
     }
 

--- a/tests/test_dictionary.c
+++ b/tests/test_dictionary.c
@@ -36,6 +36,73 @@ Test(dictionary, free) {
 }
 
 /*
+************ dict_chars_exists tests ****************************
+*/
+
+Test(dictionary, dict_chars_list_f0) {
+    dict_t *d;
+    int rc;
+
+    d = dict_new();
+
+    rc = dict_chars_exists(d, 'c');
+
+    cr_assert_eq(rc, EXIT_FAILURE, "dict_chars_exists succeeded when it shouldn't have");
+}
+
+Test(dictionary, dict_chars_list_f1) {
+    dict_t *d;
+    int rc;
+
+    d = dict_new();
+
+    dict_add(d, "candy");
+
+    rc = dict_chars_exists(d, '7');
+
+    cr_assert_eq(rc, EXIT_FAILURE, "dict_chars_exists succeeded when it shouldn't have");
+}
+
+Test(dictionary, dict_chars_list_s0) {
+    dict_t *d;
+    int rc;
+
+    d = dict_new();
+
+    dict_add(d, "jkl538-yfv");
+
+    rc = dict_chars_exists(d, '-');
+
+    cr_assert_eq(rc, EXIT_SUCCESS, "dict_chars_exists failed when it should have succeeded");
+}
+
+Test(dictionary, dict_chars_list_s1) {
+    dict_t *d;
+    int rc;
+
+    d = dict_new();
+
+    dict_add(d, "candy");
+
+    rc = dict_chars_exists(d, 'd');
+
+    cr_assert_eq(rc, EXIT_SUCCESS, "dict_chars_exists failed when it should have succeeded");
+}
+
+Test(dictionary, dict_chars_list_null) {
+    dict_t *d;
+    int rc;
+
+    d = dict_new();
+
+    dict_add(d, "");
+
+    rc = dict_chars_exists(d, '\0');
+
+    cr_assert_eq(rc, EXIT_FAILURE, "dict_chars_exists succeeded when it shouldn't have");
+}
+
+/*
 ************ dict_add tests ****************************
 */
 


### PR DESCRIPTION
**This code does not affect any previously written code that depended on dictionary.h in any way.**

These changes were necessary for the valid char list that is going to be used for major efficiency boosts in suggestion.c (this can speed it up by about a factor of 100 or so). Changes made:
- Added an instant lookup table to the dict_t struct to see all characters contained in a dictionary 
- Edited init and free as appropriate.
- Written functions to update and add to the list.
- Edited dict_add to also add to the char list when adding a word to the dictionary.
- Written tests for those functions.
- Added a maximum length for strings to be added to the dictionary (purely for safety in strnlen).

See complete descriptions in include/dictionary.h. 
See implementation in src/dictionary.c. 
See tests in tests/test_dictionary.c.

See successful travis build here: https://travis-ci.org/cmsc22000-project-2018/spellcheck/builds/380528247

_Note- this branch could not be pulled from dev since dev is contaminated with unpulled shell code. As such, I had to pull this from master and use this branch as a staging branch._

_Note 2: Added another .gitignore item that has been bothering me for a while. This file is associated with VSCode personal settings only._

_Note to reviewers: due to github's formatting, it looks like dict_exists was modified. However, to see where the changes actually take place (in dict_add), expand the code with the expansion button in between lines 61 and 71 to see the actual context of the change._